### PR TITLE
refactor(interceptor): rename http user context interceptor

### DIFF
--- a/lib/apm/apm.module.ts
+++ b/lib/apm/apm.module.ts
@@ -9,7 +9,7 @@ import {
 import { getInstance } from './apm.util';
 import { ApmAsyncOptions, ApmOptions } from './interface';
 import { FactoryProvider } from '@nestjs/common/interfaces';
-import { ApmUserContextInterceptor } from './service/apm-user-context.interceptor';
+import { ApmHttpUserContextInterceptor } from './service/apm-http-user-context-interceptor.service';
 import { ApmErrorInterceptor } from './service/apm-error.interceptor';
 
 const providers: Provider[] = [
@@ -22,9 +22,9 @@ const providers: Provider[] = [
     },
   },
   {
-    provide: ApmUserContextInterceptor,
+    provide: ApmHttpUserContextInterceptor,
     useFactory: (apmService: ApmService, apmOptions: ApmOptions) => {
-      return new ApmUserContextInterceptor(
+      return new ApmHttpUserContextInterceptor(
         apmService,
         apmOptions.httpUserMapFunction,
       );
@@ -59,7 +59,7 @@ export class ApmModule {
         ApmService,
         APM_INSTANCE,
         APM_MIDDLEWARE,
-        ApmUserContextInterceptor,
+        ApmHttpUserContextInterceptor,
         APM_OPTIONS,
       ],
       module: ApmModule,

--- a/lib/apm/service/apm-http-user-context-interceptor.service.ts
+++ b/lib/apm/service/apm-http-user-context-interceptor.service.ts
@@ -1,12 +1,11 @@
 import { CallHandler } from '@nestjs/common/interfaces/features/nest-interceptor.interface';
-import { ExecutionContext, Injectable, Logger } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { ApmService } from './apm.service';
 import { ApmInterceptorConstructor, UserContextKeys } from '../interface';
-import { catchError } from 'rxjs/operators';
 
 @Injectable()
-export class ApmUserContextInterceptor extends ApmInterceptorConstructor {
+export class ApmHttpUserContextInterceptor extends ApmInterceptorConstructor {
   constructor(
     protected readonly apmService: ApmService,
     protected readonly mapFunction?: (request: any) => UserContextKeys,

--- a/lib/apm/service/index.ts
+++ b/lib/apm/service/index.ts
@@ -1,3 +1,3 @@
 export * from './apm.service';
 export * from './apm-error.interceptor';
-export * from './apm-user-context.interceptor';
+export * from './apm-http-user-context-interceptor.service';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nestjs-lib-starter",
+  "name": "elastic-apm-nest",
   "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
@@ -502,26 +502,57 @@
       }
     },
     "@nestjs/common": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-6.5.3.tgz",
-      "integrity": "sha512-8d39grIMrUYGKM46BFWxB6csQFCu1S2aK7azPivg7gTRVSbvR84cVd6tgRVM0LwFpqQrtn3Q6G6Pa8FSk7Kh1w==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-7.0.3.tgz",
+      "integrity": "sha512-ENfgocjBC8aWAvvjjCq/JFN94CIVX4FrXr12r66UEcw/GtCW/qAc/BVWGX//7MRtk95me82hBEQQx2kovL91bA==",
       "requires": {
-        "axios": "0.19.0",
-        "cli-color": "1.4.0",
-        "uuid": "3.3.2"
+        "axios": "0.19.2",
+        "cli-color": "2.0.0",
+        "tslib": "1.11.1",
+        "uuid": "7.0.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+        },
+        "uuid": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+          "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+        }
       }
     },
     "@nestjs/core": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-6.5.3.tgz",
-      "integrity": "sha512-ZhYfH49sVmUUw02qsaGozCFOOehlEABakYzRShyDDq30/2+ek3KpE0DfvA9tXlzX2KVrac2qDTBxMOPoJ+zY+g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-7.0.3.tgz",
+      "integrity": "sha512-uIIcM+a2IoV2aqHHMtnDGOy81CMNNNm3xpJIFLjS74OqCGpE4skqiFIZRsB1cIeip1EtVh7IzU0xXo0JrIZEQA==",
       "requires": {
         "@nuxtjs/opencollective": "0.2.2",
-        "fast-safe-stringify": "2.0.6",
+        "fast-safe-stringify": "2.0.7",
         "iterare": "1.2.0",
-        "object-hash": "1.3.1",
-        "optional": "0.1.4",
-        "uuid": "3.3.2"
+        "object-hash": "2.0.3",
+        "path-to-regexp": "3.2.0",
+        "tslib": "1.11.1",
+        "uuid": "7.0.2"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
+          "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA=="
+        },
+        "tslib": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+        },
+        "uuid": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+          "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+        }
       }
     },
     "@nestjs/platform-express": {
@@ -1021,12 +1052,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
+        "follow-redirects": "1.5.10"
       }
     },
     "babel-jest": {
@@ -1531,16 +1561,16 @@
       }
     },
     "cli-color": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
-      "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.0.tgz",
+      "integrity": "sha512-a0VZ8LeraW0jTuCkuAGMNufareGHhyZU9z8OGsW0gXd1hZGi1SRuNRXdbGkraBBKnhyUhyebFWnRbp+dIn0f0A==",
       "requires": {
         "ansi-regex": "^2.1.1",
-        "d": "1",
-        "es5-ext": "^0.10.46",
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.51",
         "es6-iterator": "^2.0.3",
         "memoizee": "^0.4.14",
-        "timers-ext": "^0.1.5"
+        "timers-ext": "^0.1.7"
       }
     },
     "cli-cursor": {
@@ -1758,9 +1788,9 @@
       }
     },
     "consola": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.10.1.tgz",
-      "integrity": "sha512-4sxpH6SGFYLADfUip4vuY65f/gEogrzJoniVhNUYkJHtng0l8ZjnDCqxxrSVRHOHwKxsy8Vm5ONZh1wOR3/l/w=="
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.11.3.tgz",
+      "integrity": "sha512-aoW0YIIAmeftGR8GSpw6CGQluNdkWMWh3yEFjH/hmynTYnMtibXszii3lxCXmk8YxJtI3FAK5aTiquA5VH68Gw=="
     },
     "console-log-level": {
       "version": "1.4.1",
@@ -2747,13 +2777,13 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.50",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
-      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
       "requires": {
         "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "^1.0.0"
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
       }
     },
     "es6-iterator": {
@@ -2767,12 +2797,12 @@
       }
     },
     "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
       }
     },
     "es6-weak-map": {
@@ -2991,6 +3021,21 @@
         }
       }
     },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3178,9 +3223,9 @@
       "dev": true
     },
     "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fast-stream-to-buffer": {
       "version": "1.0.0",
@@ -4828,11 +4873,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-    },
-    "is-buffer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -6883,9 +6923,9 @@
       "integrity": "sha512-CsubGNxhIEChNY4cXYuA6KXafztzHqzLLZ/y3Kasf3A+sa3lL9thq3z+7o0pZqzEinjXT6lXDPAfVWI59dUyzQ=="
     },
     "object-hash": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.3.tgz",
+      "integrity": "sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg=="
     },
     "object-identity-map": {
       "version": "1.0.2",
@@ -7056,7 +7096,8 @@
     "optional": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
-      "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw=="
+      "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
+      "dev": true
     },
     "optional-js": {
       "version": "2.1.1",
@@ -9090,9 +9131,9 @@
       "dev": true
     },
     "type": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
-      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -9264,7 +9305,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
     "elastic-apm-node": "^3.3.0"
   },
   "devDependencies": {
-    "@nestjs/common": "6.5.3",
-    "@nestjs/core": "6.5.3",
     "@nestjs/platform-express": "^6.10.8",
     "@nestjs/testing": "^6.5.3",
     "@types/jest": "24.0.17",
@@ -80,8 +78,8 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "@nestjs/common": "^6.5.3",
-    "@nestjs/core": "^6.5.3",
+    "@nestjs/common": "^7.0.3",
+    "@nestjs/core": "^7.0.3",
     "elastic-apm-node": "^3.3.0",
     "reflect-metadata": "^0.1.13"
   },

--- a/test/apm/apm-error.interceptor.e2e-spec.ts
+++ b/test/apm/apm-error.interceptor.e2e-spec.ts
@@ -21,7 +21,7 @@ import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ApmModule } from '../../lib/apm/apm.module';
-import { ApmUserContextInterceptor } from '../../lib/apm/service/apm-user-context.interceptor';
+import { ApmHttpUserContextInterceptor } from '../../lib/apm/service/apm-http-user-context-interceptor.service';
 import { ApmErrorInterceptor } from '../../lib/apm/service/apm-error.interceptor';
 
 @Controller()

--- a/test/apm/apm-user-context.interceptor.e2e-spec.ts
+++ b/test/apm/apm-user-context.interceptor.e2e-spec.ts
@@ -21,7 +21,7 @@ import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ApmModule } from '../../lib/apm/apm.module';
-import { ApmUserContextInterceptor } from '../../lib/apm/service/apm-user-context.interceptor';
+import { ApmHttpUserContextInterceptor } from '../../lib/apm/service/apm-http-user-context-interceptor.service';
 
 @Controller()
 class TestController {
@@ -74,7 +74,7 @@ describe('ApmHttpInterceptor', () => {
         providers: [
           {
             provide: APP_INTERCEPTOR,
-            useExisting: ApmUserContextInterceptor,
+            useExisting: ApmHttpUserContextInterceptor,
           },
         ],
       }).compile();

--- a/test/apm/apm.module.spec.ts
+++ b/test/apm/apm.module.spec.ts
@@ -14,7 +14,7 @@ jest.mock('elastic-apm-node', () => ({
   }),
 }));
 
-import { ApmUserContextInterceptor } from '../../lib/apm/service/apm-user-context.interceptor';
+import { ApmHttpUserContextInterceptor } from '../../lib/apm/service/apm-http-user-context-interceptor.service';
 import {
   APM_INSTANCE,
   APM_MIDDLEWARE,
@@ -35,7 +35,7 @@ describe('apm.module', () => {
       expect(app.get(APM_OPTIONS)).toBeDefined();
       expect(app.get(APM_INSTANCE)).toBeDefined();
       expect(app.get(APM_MIDDLEWARE)).toBeDefined();
-      expect(ApmUserContextInterceptor).toBeDefined();
+      expect(ApmHttpUserContextInterceptor).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
Developers were confused with the interceptor. Renamed ApmUserContextInterceptor to
ApmHttpUserContextInterceptor to avoid this. Updated nestjs packages aswell.

re #4 